### PR TITLE
fix: use type-only imports for AxiosInstance and AxiosError

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-34-7b7598c3
-Your prepared working directory: /tmp/gh-issue-solver-1761658025895
-Your forked repository: konard/TaskMateFrontend
-Original repository (upstream): xierongchuan/TaskMateFrontend
-
-Proceed.


### PR DESCRIPTION
## 🎯 Summary

This PR fixes the TypeScript compilation error (TS1484) that was preventing the project from building successfully.

## 📋 Issue Reference

Fixes #34

## 🔍 Problem

The build was failing with this error:
```
src/api/client.ts:1:17 - error TS1484: 'AxiosInstance' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
```

This error occurs because the project has `verbatimModuleSyntax: true` enabled in `tsconfig.app.json`, which requires that type imports must use the `type` keyword to distinguish them from value imports.

## ✅ Solution

Changed the import statement in `src/api/client.ts` from:
```typescript
import axios, { AxiosInstance, AxiosError } from 'axios';
```

to:
```typescript
import axios, { type AxiosInstance, type AxiosError } from 'axios';
```

## 🧪 Testing

- ✅ TypeScript compilation passes without errors (`npx tsc -b`)
- ✅ Full TypeScript check passes (`npx tsc --noEmit`)
- ✅ No similar import issues found in other files

## 📝 Changes

- Modified `src/api/client.ts:1` to use type-only imports for `AxiosInstance` and `AxiosError`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)