### PR TITLE
Добавить автосалон в форму важных ссылок

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-18T15:18:27.218Z for PR creation at branch issue-66-5a74d5769c36 for issue https://github.com/xierongchuan/TaskMateClient/issues/66

--- a/src/api/links.ts
+++ b/src/api/links.ts
@@ -5,6 +5,7 @@ import type { PaginatedResponse } from '../types/api';
 export interface LinksFilters {
   search?: string;
   category?: string;
+  dealership_id?: number;
   per_page?: number;
   page?: number;
 }

--- a/src/pages/LinksPage.tsx
+++ b/src/pages/LinksPage.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { linksApi } from '../api/links';
 import { usePermissions } from '../hooks/usePermissions';
 import { useResponsiveViewMode } from '../hooks/useResponsiveViewMode';
 import { usePagination } from '../hooks/usePagination';
+import { useWorkspace } from '../hooks/useWorkspace';
 import type { Link, CreateLinkRequest } from '../types/link';
 import {
   PlusIcon,
@@ -39,9 +40,11 @@ import {
   FormField,
 } from '../components/ui';
 import { ActionButtons } from '../components/common';
+import { DealershipSelector } from '../components/common/DealershipSelector';
 
 export const LinksPage: React.FC = () => {
   const permissions = usePermissions();
+  const { dealershipId: workspaceDealershipId, currentDealership } = useWorkspace();
   const queryClient = useQueryClient();
   const { limit } = usePagination();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -55,6 +58,7 @@ export const LinksPage: React.FC = () => {
     url: '',
     description: '',
     category: 'general',
+    dealership_id: workspaceDealershipId || 0,
   });
 
   // Reset page on search change
@@ -63,12 +67,17 @@ export const LinksPage: React.FC = () => {
     setPage(1);
   };
 
+  useEffect(() => {
+    setPage(1);
+  }, [workspaceDealershipId]);
+
   const { data: linksData, isLoading, error, refetch } = useQuery({
-    queryKey: ['links', page, limit, searchTerm],
+    queryKey: ['links', workspaceDealershipId, page, limit, searchTerm],
     queryFn: () => linksApi.getLinks({
       page,
       per_page: limit,
-      search: searchTerm
+      search: searchTerm,
+      dealership_id: workspaceDealershipId || undefined,
     }),
     placeholderData: (prev) => prev,
   });
@@ -101,7 +110,13 @@ export const LinksPage: React.FC = () => {
   });
 
   const resetForm = () => {
-    setFormData({ title: '', url: '', description: '', category: 'general' });
+    setFormData({
+      title: '',
+      url: '',
+      description: '',
+      category: 'general',
+      dealership_id: workspaceDealershipId || 0,
+    });
     setSelectedLink(null);
   };
 
@@ -144,7 +159,14 @@ export const LinksPage: React.FC = () => {
   }, {} as Record<string, Link[]>);
 
   const handleCreate = () => {
-    resetForm();
+    setFormData({
+      title: '',
+      url: '',
+      description: '',
+      category: 'general',
+      dealership_id: workspaceDealershipId || 0,
+    });
+    setSelectedLink(null);
     setIsModalOpen(true);
   };
 
@@ -155,6 +177,7 @@ export const LinksPage: React.FC = () => {
       url: link.url,
       description: link.description || '',
       category: link.category || 'general',
+      dealership_id: link.dealership_id,
     });
     setIsModalOpen(true);
   };
@@ -165,6 +188,8 @@ export const LinksPage: React.FC = () => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (!formData.dealership_id) return;
+
     if (selectedLink) {
       updateMutation.mutate({ id: selectedLink.id, data: formData });
     } else {
@@ -334,6 +359,11 @@ export const LinksPage: React.FC = () => {
                             <Badge variant="gray">
                               {getCategoryLabel(link.category || 'general')}
                             </Badge>
+                            {link.dealership?.name && (
+                              <Badge variant="info">
+                                {link.dealership.name}
+                              </Badge>
+                            )}
                           </div>
                           {link.description && (
                             <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">{link.description}</p>
@@ -418,6 +448,23 @@ export const LinksPage: React.FC = () => {
                 />
               </FormField>
 
+              <FormField label="Автосалон" required>
+                <DealershipSelector
+                  value={formData.dealership_id || null}
+                  onChange={(dealershipId) => setFormData({
+                    ...formData,
+                    dealership_id: dealershipId || 0,
+                  })}
+                  placeholder="Выберите автосалон"
+                  required
+                />
+                {currentDealership && formData.dealership_id === currentDealership.id && (
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    Используется текущий автосалон: {currentDealership.name}
+                  </p>
+                )}
+              </FormField>
+
               <FormField label="Описание">
                 <Textarea
                   value={formData.description}
@@ -433,6 +480,7 @@ export const LinksPage: React.FC = () => {
               type="submit"
               variant="primary"
               isLoading={createMutation.isPending || updateMutation.isPending}
+              disabled={!formData.dealership_id}
             >
               {selectedLink ? 'Сохранить' : 'Создать'}
             </Button>

--- a/src/types/link.ts
+++ b/src/types/link.ts
@@ -5,12 +5,16 @@ export interface Link {
   description?: string;
   category?: string;
   creator_id: number;
-  dealership_id?: number;
+  dealership_id: number;
   created_at: string;
   updated_at: string;
   creator?: {
     id: number;
     full_name: string;
+  };
+  dealership?: {
+    id: number;
+    name: string;
   };
 }
 
@@ -19,6 +23,7 @@ export interface CreateLinkRequest {
   url: string;
   description?: string;
   category?: string;
+  dealership_id: number;
 }
 
 export interface UpdateLinkRequest {
@@ -26,4 +31,5 @@ export interface UpdateLinkRequest {
   url?: string;
   description?: string;
   category?: string;
+  dealership_id?: number;
 }


### PR DESCRIPTION
## Summary
- Added required dealership selection to the Important Links create/edit modal.
- Sent `dealership_id` in create/update requests and added `dealership_id` filtering to the links API request.
- Scoped the links query key by workspace dealership and reset pagination when the workspace dealership changes.
- Added dealership typing on link responses and display the dealership badge in list view when returned by the API.

Fixes xierongchuan/TaskMateClient#66

## Verification
- `npm run build` passes.
- `npx tsc -b --pretty false` passes.
- `npm run lint` currently fails on pre-existing repository lint issues outside this change, including `no-explicit-any`, `react-refresh/only-export-components`, and unused variables in unrelated files/tests.

## Notes
- `npm ci` completed with an engine warning because this environment runs Node 20 while `@capacitor/cli@8.1.0` declares Node >=22.
